### PR TITLE
Fix Bitwarden plugin

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -121,7 +121,7 @@ class Plugin(PluginInstance, GeneratorQueryHandler):
                 )
             )
 
-        yield [results]
+        yield results
 
     def _get_items(self):
         not_first_time = self._cached_items is not None

--- a/__init__.py
+++ b/__init__.py
@@ -162,7 +162,7 @@ class Plugin(PluginInstance, GeneratorQueryHandler):
         passwords = self._get_items() or []
         search_fields = ["path", "user"]
         # Use a set for faster membership tests
-        words = set(query.string.strip().lower().split())
+        words = set(query.strip().lower().split())
 
         filtered_passwords = []
 


### PR DESCRIPTION
This PR fixes two errors that prevent the Bitwarden search results to be returned:

1. The returned items are already in a list. But it was wrongly nested in another list in the `yield` statement.
2. `ctx.query` is already a `str` object, which doesn't have a `string` attribute.

Tested on Albert 34.0.1, with Python 3.14.2.